### PR TITLE
Fix line height measurement being off by one character

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -176,7 +176,7 @@ class _TextEditorWithLineNumbersState extends State<TextEditorWithLineNumbers> {
     for (final length in lengths) {
       yield TextSelection(
           baseOffset: base,
-          extentOffset: length == 0 ? base : base + length - 1);
+          extentOffset: length == 0 ? base : base + length);
       base = base + length + 1;
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -132,12 +132,14 @@ class _TextEditorWithLineNumbersState extends State<TextEditorWithLineNumbers> {
       final lengths = _getLineLengths(value);
       final selections = _getTextSelections(lengths);
       _log('');
-      final singleLineHeight = _getSingleLineHeight(ets);
-      final heights = [
-        for (final sel in selections)
-          _getWrappedLineHeight(ets, sel, singleLineHeight)
-      ];
-      setState(() => _lineHeights = heights.toList());
+      WidgetsBinding.instance!.addPostFrameCallback((_) {
+        final singleLineHeight = _getSingleLineHeight(ets);
+        final heights = [
+          for (final sel in selections)
+            _getWrappedLineHeight(ets, sel, singleLineHeight)
+        ];
+        setState(() => _lineHeights = heights.toList());
+      });
     }
   }
 


### PR DESCRIPTION
Feel free to close this and fix this your own way if you want, I'm mainly using this to show what I found was wrong.

Also, I didn't really QA this very thoroughly, but it seemed to fix the direct problem that you showed in your [doc](https://docs.google.com/document/d/156iCM9uxvL286Gb3UMaX9wpXsKFJBe2sy-oDxnJAsFQ/edit#).

### The problem

First of all, there seemed to be an off by one error in the iteration when calculating selections, fixed in 6f6cb6a.

Secondly, in fact there was a race condition that needed to be fixed with an addPostFrameCallback.  At the time onChanged is called, TextPainter has not yet been updated to contain the new changes, so calls to getEndpointsForSelection will be out of date.  This is an architectural problem that we're aware of.