### PR TITLE
Simplifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -138,7 +138,7 @@ class _TextEditorWithLineNumbersState extends State<TextEditorWithLineNumbers> {
           for (final sel in selections)
             _getWrappedLineHeight(ets, sel, singleLineHeight)
         ];
-        setState(() => _lineHeights = heights.toList());
+        setState(() => _lineHeights = heights);
       });
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -177,8 +177,7 @@ class _TextEditorWithLineNumbersState extends State<TextEditorWithLineNumbers> {
     var base = 0;
     for (final length in lengths) {
       yield TextSelection(
-          baseOffset: base,
-          extentOffset: length == 0 ? base : base + length);
+          baseOffset: base, extentOffset: length == 0 ? base : base + length);
       base = base + length + 1;
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -176,8 +176,7 @@ class _TextEditorWithLineNumbersState extends State<TextEditorWithLineNumbers> {
   Iterable<TextSelection> _getTextSelections(Iterable<int> lengths) sync* {
     var base = 0;
     for (final length in lengths) {
-      yield TextSelection(
-          baseOffset: base, extentOffset: length == 0 ? base : base + length);
+      yield TextSelection(baseOffset: base, extentOffset: base + length);
       base = base + length + 1;
     }
   }


### PR DESCRIPTION
I'm curious if the `toList()` call on the `heights` list is there for a specific reason, or if it is just something left over from earlier versions.